### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Context
+
+## Scope of Change
+
+## Tests
+
+## Risk/Rollback
+


### PR DESCRIPTION
## Summary
- add default pull request template to standardize new PR descriptions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trafilatura')*

------
https://chatgpt.com/codex/tasks/task_e_689a2a71d4748331a3147843dfe89c9e

## Summary by Sourcery

Documentation:
- Introduce a default pull request template file with Context, Scope of Change, Tests, and Risk/Rollback sections